### PR TITLE
Fixes the SVG issues with "none" interpolation

### DIFF
--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -764,11 +764,12 @@ class RendererSVG(RendererBase):
                 width=str(w), height=str(h),
                 attrib=attrib)
         else:
+            flipped = self._make_flip_transform(transform)
             attrib['transform'] = generate_transform(
-                [('matrix', transform.to_values())])
+                [('matrix', flipped.to_values())])
             self.writer.element(
                 'image',
-                x=str(x), y=str(y), width=str(dx), height=str(dy),
+                x=str(x), y=str(y+dy), width=str(dx), height=str(-dy),
                 attrib=attrib)
 
         if url is not None:

--- a/lib/matplotlib/tests/baseline_images/test_image/interp_nearest_vs_none.svg
+++ b/lib/matplotlib/tests/baseline_images/test_image/interp_nearest_vs_none.svg
@@ -29,10 +29,10 @@ z
 " style="fill:#ffffff;"/>
    </g>
    <g clip-path="url(#p340d592a0b)">
-    <image height="-2.0" transform="matrix(101.454545455 0.0 0.0 -101.454545455 122.727272727 266.727272727)" width="2.0" x="-0.5" xlink:href="data:image/png;base64,
+    <image height="2.0" transform="matrix(101.454545455 0.0 0.0 101.454545455 122.727272727 165.272727273)" width="2.0" x="-0.5" xlink:href="data:image/png;base64,
 iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAABHNCSVQICAgIfAhkiAAAABtJREFU
 CJljvrVU8T+v6L0GhoZ/DP//JXv8BwBPvwlIEKcPcwAAAABJRU5ErkJggg==
-" y="1.5"/>
+" y="-0.5"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -40,20 +40,20 @@ CJljvrVU8T+v6L0GhoZ/DP//JXv8BwBPvwlIEKcPcwAAAABJRU5ErkJggg==
       <defs>
        <path d="
 M0 0
-L0 -4" id="mcfcb760c08"/>
+L0 -4" id="m13b57186d2"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="72.0" xlink:href="#mcfcb760c08" y="317.454545455"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="72.0" xlink:href="#m13b57186d2" y="317.454545455"/>
       </g>
      </g>
      <g id="line2d_2">
       <defs>
        <path d="
 M0 0
-L0 4" id="m5ee09eb6c1"/>
+L0 4" id="m18a4b09ce5"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="72.0" xlink:href="#m5ee09eb6c1" y="114.545454545"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="72.0" xlink:href="#m18a4b09ce5" y="114.545454545"/>
       </g>
      </g>
      <g id="text_1">
@@ -131,20 +131,20 @@ z
       <defs>
        <path d="
 M0 0
-L0 -4" id="mcfcb760c08"/>
+L0 -4" id="m13b57186d2"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="122.727272727" xlink:href="#mcfcb760c08" y="317.454545455"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="122.727272727" xlink:href="#m13b57186d2" y="317.454545455"/>
       </g>
      </g>
      <g id="line2d_4">
       <defs>
        <path d="
 M0 0
-L0 4" id="m5ee09eb6c1"/>
+L0 4" id="m18a4b09ce5"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="122.727272727" xlink:href="#m5ee09eb6c1" y="114.545454545"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="122.727272727" xlink:href="#m18a4b09ce5" y="114.545454545"/>
       </g>
      </g>
      <g id="text_2">
@@ -161,20 +161,20 @@ L0 4" id="m5ee09eb6c1"/>
       <defs>
        <path d="
 M0 0
-L0 -4" id="mcfcb760c08"/>
+L0 -4" id="m13b57186d2"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="173.454545455" xlink:href="#mcfcb760c08" y="317.454545455"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="173.454545455" xlink:href="#m13b57186d2" y="317.454545455"/>
       </g>
      </g>
      <g id="line2d_6">
       <defs>
        <path d="
 M0 0
-L0 4" id="m5ee09eb6c1"/>
+L0 4" id="m18a4b09ce5"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="173.454545455" xlink:href="#m5ee09eb6c1" y="114.545454545"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="173.454545455" xlink:href="#m18a4b09ce5" y="114.545454545"/>
       </g>
      </g>
      <g id="text_3">
@@ -191,20 +191,20 @@ L0 4" id="m5ee09eb6c1"/>
       <defs>
        <path d="
 M0 0
-L0 -4" id="mcfcb760c08"/>
+L0 -4" id="m13b57186d2"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="224.181818182" xlink:href="#mcfcb760c08" y="317.454545455"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="224.181818182" xlink:href="#m13b57186d2" y="317.454545455"/>
       </g>
      </g>
      <g id="line2d_8">
       <defs>
        <path d="
 M0 0
-L0 4" id="m5ee09eb6c1"/>
+L0 4" id="m18a4b09ce5"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="224.181818182" xlink:href="#m5ee09eb6c1" y="114.545454545"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="224.181818182" xlink:href="#m18a4b09ce5" y="114.545454545"/>
       </g>
      </g>
      <g id="text_4">
@@ -237,20 +237,20 @@ z
       <defs>
        <path d="
 M0 0
-L0 -4" id="mcfcb760c08"/>
+L0 -4" id="m13b57186d2"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="274.909090909" xlink:href="#mcfcb760c08" y="317.454545455"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="274.909090909" xlink:href="#m13b57186d2" y="317.454545455"/>
       </g>
      </g>
      <g id="line2d_10">
       <defs>
        <path d="
 M0 0
-L0 4" id="m5ee09eb6c1"/>
+L0 4" id="m18a4b09ce5"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="274.909090909" xlink:href="#m5ee09eb6c1" y="114.545454545"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="274.909090909" xlink:href="#m18a4b09ce5" y="114.545454545"/>
       </g>
      </g>
      <g id="text_5">
@@ -269,20 +269,20 @@ L0 4" id="m5ee09eb6c1"/>
       <defs>
        <path d="
 M0 0
-L4 0" id="m84926ae074"/>
+L4 0" id="m5351898e3e"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="72.0" xlink:href="#m84926ae074" y="114.545454545"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="72.0" xlink:href="#m5351898e3e" y="114.545454545"/>
       </g>
      </g>
      <g id="line2d_12">
       <defs>
        <path d="
 M0 0
-L-4 0" id="m02d8ef48b8"/>
+L-4 0" id="md2ceb7ac7d"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="274.909090909" xlink:href="#m02d8ef48b8" y="114.545454545"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="274.909090909" xlink:href="#md2ceb7ac7d" y="114.545454545"/>
       </g>
      </g>
      <g id="text_6">
@@ -300,20 +300,20 @@ L-4 0" id="m02d8ef48b8"/>
       <defs>
        <path d="
 M0 0
-L4 0" id="m84926ae074"/>
+L4 0" id="m5351898e3e"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="72.0" xlink:href="#m84926ae074" y="165.272727273"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="72.0" xlink:href="#m5351898e3e" y="165.272727273"/>
       </g>
      </g>
      <g id="line2d_14">
       <defs>
        <path d="
 M0 0
-L-4 0" id="m02d8ef48b8"/>
+L-4 0" id="md2ceb7ac7d"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="274.909090909" xlink:href="#m02d8ef48b8" y="165.272727273"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="274.909090909" xlink:href="#md2ceb7ac7d" y="165.272727273"/>
       </g>
      </g>
      <g id="text_7">
@@ -330,20 +330,20 @@ L-4 0" id="m02d8ef48b8"/>
       <defs>
        <path d="
 M0 0
-L4 0" id="m84926ae074"/>
+L4 0" id="m5351898e3e"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="72.0" xlink:href="#m84926ae074" y="216.0"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="72.0" xlink:href="#m5351898e3e" y="216.0"/>
       </g>
      </g>
      <g id="line2d_16">
       <defs>
        <path d="
 M0 0
-L-4 0" id="m02d8ef48b8"/>
+L-4 0" id="md2ceb7ac7d"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="274.909090909" xlink:href="#m02d8ef48b8" y="216.0"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="274.909090909" xlink:href="#md2ceb7ac7d" y="216.0"/>
       </g>
      </g>
      <g id="text_8">
@@ -360,20 +360,20 @@ L-4 0" id="m02d8ef48b8"/>
       <defs>
        <path d="
 M0 0
-L4 0" id="m84926ae074"/>
+L4 0" id="m5351898e3e"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="72.0" xlink:href="#m84926ae074" y="266.727272727"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="72.0" xlink:href="#m5351898e3e" y="266.727272727"/>
       </g>
      </g>
      <g id="line2d_18">
       <defs>
        <path d="
 M0 0
-L-4 0" id="m02d8ef48b8"/>
+L-4 0" id="md2ceb7ac7d"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="274.909090909" xlink:href="#m02d8ef48b8" y="266.727272727"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="274.909090909" xlink:href="#md2ceb7ac7d" y="266.727272727"/>
       </g>
      </g>
      <g id="text_9">
@@ -390,20 +390,20 @@ L-4 0" id="m02d8ef48b8"/>
       <defs>
        <path d="
 M0 0
-L4 0" id="m84926ae074"/>
+L4 0" id="m5351898e3e"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="72.0" xlink:href="#m84926ae074" y="317.454545455"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="72.0" xlink:href="#m5351898e3e" y="317.454545455"/>
       </g>
      </g>
      <g id="line2d_20">
       <defs>
        <path d="
 M0 0
-L-4 0" id="m02d8ef48b8"/>
+L-4 0" id="md2ceb7ac7d"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="274.909090909" xlink:href="#m02d8ef48b8" y="317.454545455"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="274.909090909" xlink:href="#md2ceb7ac7d" y="317.454545455"/>
       </g>
      </g>
      <g id="text_10">
@@ -670,20 +670,20 @@ EAwEgoFAMBAIBgLBQCAYCAQDgWAgEAwEX/HUCgtErBocAAAAAElFTkSuQmCC
       <defs>
        <path d="
 M0 0
-L0 -4" id="mcfcb760c08"/>
+L0 -4" id="m13b57186d2"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="315.490909091" xlink:href="#mcfcb760c08" y="317.454545455"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="315.490909091" xlink:href="#m13b57186d2" y="317.454545455"/>
       </g>
      </g>
      <g id="line2d_22">
       <defs>
        <path d="
 M0 0
-L0 4" id="m5ee09eb6c1"/>
+L0 4" id="m18a4b09ce5"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="315.490909091" xlink:href="#m5ee09eb6c1" y="114.545454545"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="315.490909091" xlink:href="#m18a4b09ce5" y="114.545454545"/>
       </g>
      </g>
      <g id="text_12">
@@ -701,20 +701,20 @@ L0 4" id="m5ee09eb6c1"/>
       <defs>
        <path d="
 M0 0
-L0 -4" id="mcfcb760c08"/>
+L0 -4" id="m13b57186d2"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="366.218181818" xlink:href="#mcfcb760c08" y="317.454545455"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="366.218181818" xlink:href="#m13b57186d2" y="317.454545455"/>
       </g>
      </g>
      <g id="line2d_24">
       <defs>
        <path d="
 M0 0
-L0 4" id="m5ee09eb6c1"/>
+L0 4" id="m18a4b09ce5"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="366.218181818" xlink:href="#m5ee09eb6c1" y="114.545454545"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="366.218181818" xlink:href="#m18a4b09ce5" y="114.545454545"/>
       </g>
      </g>
      <g id="text_13">
@@ -731,20 +731,20 @@ L0 4" id="m5ee09eb6c1"/>
       <defs>
        <path d="
 M0 0
-L0 -4" id="mcfcb760c08"/>
+L0 -4" id="m13b57186d2"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="416.945454545" xlink:href="#mcfcb760c08" y="317.454545455"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="416.945454545" xlink:href="#m13b57186d2" y="317.454545455"/>
       </g>
      </g>
      <g id="line2d_26">
       <defs>
        <path d="
 M0 0
-L0 4" id="m5ee09eb6c1"/>
+L0 4" id="m18a4b09ce5"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="416.945454545" xlink:href="#m5ee09eb6c1" y="114.545454545"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="416.945454545" xlink:href="#m18a4b09ce5" y="114.545454545"/>
       </g>
      </g>
      <g id="text_14">
@@ -761,20 +761,20 @@ L0 4" id="m5ee09eb6c1"/>
       <defs>
        <path d="
 M0 0
-L0 -4" id="mcfcb760c08"/>
+L0 -4" id="m13b57186d2"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="467.672727273" xlink:href="#mcfcb760c08" y="317.454545455"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="467.672727273" xlink:href="#m13b57186d2" y="317.454545455"/>
       </g>
      </g>
      <g id="line2d_28">
       <defs>
        <path d="
 M0 0
-L0 4" id="m5ee09eb6c1"/>
+L0 4" id="m18a4b09ce5"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="467.672727273" xlink:href="#m5ee09eb6c1" y="114.545454545"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="467.672727273" xlink:href="#m18a4b09ce5" y="114.545454545"/>
       </g>
      </g>
      <g id="text_15">
@@ -791,20 +791,20 @@ L0 4" id="m5ee09eb6c1"/>
       <defs>
        <path d="
 M0 0
-L0 -4" id="mcfcb760c08"/>
+L0 -4" id="m13b57186d2"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="518.4" xlink:href="#mcfcb760c08" y="317.454545455"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="518.4" xlink:href="#m13b57186d2" y="317.454545455"/>
       </g>
      </g>
      <g id="line2d_30">
       <defs>
        <path d="
 M0 0
-L0 4" id="m5ee09eb6c1"/>
+L0 4" id="m18a4b09ce5"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="518.4" xlink:href="#m5ee09eb6c1" y="114.545454545"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="518.4" xlink:href="#m18a4b09ce5" y="114.545454545"/>
       </g>
      </g>
      <g id="text_16">
@@ -823,20 +823,20 @@ L0 4" id="m5ee09eb6c1"/>
       <defs>
        <path d="
 M0 0
-L4 0" id="m84926ae074"/>
+L4 0" id="m5351898e3e"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="315.490909091" xlink:href="#m84926ae074" y="114.545454545"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="315.490909091" xlink:href="#m5351898e3e" y="114.545454545"/>
       </g>
      </g>
      <g id="line2d_32">
       <defs>
        <path d="
 M0 0
-L-4 0" id="m02d8ef48b8"/>
+L-4 0" id="md2ceb7ac7d"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="518.4" xlink:href="#m02d8ef48b8" y="114.545454545"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="518.4" xlink:href="#md2ceb7ac7d" y="114.545454545"/>
       </g>
      </g>
      <g id="text_17">
@@ -854,20 +854,20 @@ L-4 0" id="m02d8ef48b8"/>
       <defs>
        <path d="
 M0 0
-L4 0" id="m84926ae074"/>
+L4 0" id="m5351898e3e"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="315.490909091" xlink:href="#m84926ae074" y="165.272727273"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="315.490909091" xlink:href="#m5351898e3e" y="165.272727273"/>
       </g>
      </g>
      <g id="line2d_34">
       <defs>
        <path d="
 M0 0
-L-4 0" id="m02d8ef48b8"/>
+L-4 0" id="md2ceb7ac7d"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="518.4" xlink:href="#m02d8ef48b8" y="165.272727273"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="518.4" xlink:href="#md2ceb7ac7d" y="165.272727273"/>
       </g>
      </g>
      <g id="text_18">
@@ -884,20 +884,20 @@ L-4 0" id="m02d8ef48b8"/>
       <defs>
        <path d="
 M0 0
-L4 0" id="m84926ae074"/>
+L4 0" id="m5351898e3e"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="315.490909091" xlink:href="#m84926ae074" y="216.0"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="315.490909091" xlink:href="#m5351898e3e" y="216.0"/>
       </g>
      </g>
      <g id="line2d_36">
       <defs>
        <path d="
 M0 0
-L-4 0" id="m02d8ef48b8"/>
+L-4 0" id="md2ceb7ac7d"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="518.4" xlink:href="#m02d8ef48b8" y="216.0"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="518.4" xlink:href="#md2ceb7ac7d" y="216.0"/>
       </g>
      </g>
      <g id="text_19">
@@ -914,20 +914,20 @@ L-4 0" id="m02d8ef48b8"/>
       <defs>
        <path d="
 M0 0
-L4 0" id="m84926ae074"/>
+L4 0" id="m5351898e3e"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="315.490909091" xlink:href="#m84926ae074" y="266.727272727"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="315.490909091" xlink:href="#m5351898e3e" y="266.727272727"/>
       </g>
      </g>
      <g id="line2d_38">
       <defs>
        <path d="
 M0 0
-L-4 0" id="m02d8ef48b8"/>
+L-4 0" id="md2ceb7ac7d"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="518.4" xlink:href="#m02d8ef48b8" y="266.727272727"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="518.4" xlink:href="#md2ceb7ac7d" y="266.727272727"/>
       </g>
      </g>
      <g id="text_20">
@@ -944,20 +944,20 @@ L-4 0" id="m02d8ef48b8"/>
       <defs>
        <path d="
 M0 0
-L4 0" id="m84926ae074"/>
+L4 0" id="m5351898e3e"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="315.490909091" xlink:href="#m84926ae074" y="317.454545455"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="315.490909091" xlink:href="#m5351898e3e" y="317.454545455"/>
       </g>
      </g>
      <g id="line2d_40">
       <defs>
        <path d="
 M0 0
-L-4 0" id="m02d8ef48b8"/>
+L-4 0" id="md2ceb7ac7d"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="518.4" xlink:href="#m02d8ef48b8" y="317.454545455"/>
+       <use style="stroke:#000000;stroke-linecap:butt;stroke-width:0.5;" x="518.4" xlink:href="#md2ceb7ac7d" y="317.454545455"/>
       </g>
      </g>
      <g id="text_21">


### PR DESCRIPTION
Fix images with "none" interpolation in the SVG backend.  Inkscape doesn't like images with negative dimensions, so change to positive and adjust the offset accordingly.
